### PR TITLE
Now we are using System.loadLibrary and System.load properly

### DIFF
--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,3 +1,4 @@
 # Enable auto-env through the sdkman_auto_env config
 # Add key=value pairs of SDKs to use below
 java=11.0.15.9.1-amzn
+# java=17.0.2.8.1-amzn

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ apply plugin: 'jacoco'
 
 allprojects {
     group = 'io.emeraldpay.polkaj'
-    version = "0.3.1.4"
+    version = "0.3.1.5"
 
     repositories {
         mavenLocal()


### PR DESCRIPTION
Because in Java 15 it seems the hack to reload the classpath at runtime
will not longer work. Specifically the usr_paths is no longer a private
member. Using System.load() as oppose to System.loadLibrary() gets
around the need to munge the classpath at runtime and thus makes this
work with Java 17 just fine. We left the System.loadLibrary path
specifically for CI as it's not packaged in a jar at that point and the
native library file is not found to be extracted